### PR TITLE
Add Erubi::VERSION

### DIFF
--- a/erubi.gemspec
+++ b/erubi.gemspec
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+require File.expand_path("../lib/erubi/version", __FILE__)
+
 Gem::Specification.new do |s|
   s.name = 'erubi'
-  s.version = '1.5.0'
+  s.version = Erubi::VERSION
   s.platform = Gem::Platform::RUBY
   s.has_rdoc = true
   s.extra_rdoc_files = ["README.rdoc", "CHANGELOG", "MIT-LICENSE"]

--- a/lib/erubi.rb
+++ b/lib/erubi.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'erubi/version'
+
 module Erubi
   ESCAPE_TABLE = {'&' => '&amp;'.freeze, '<' => '&lt;'.freeze, '>' => '&gt;'.freeze, '"' => '&quot;'.freeze, "'" => '&#039;'.freeze}.freeze
   RANGE_ALL = 0..-1

--- a/lib/erubi/version.rb
+++ b/lib/erubi/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Erubi
+  VERSION = '1.5.0'
+end


### PR DESCRIPTION
I tried to run [this benchmark](https://github.com/k0kubun/hamlit/blob/442c5604fce79ec663330ace48f42f2bd26c49c8/benchmarks/benchmark.rb#L52-L56) with erubi. 
But, erubi has not `Erubi::VERSION`. So, I added it. 

