### PR TITLE
Use ERB::Util.h instead of gsub for HTML escape

### DIFF
--- a/lib/erubi.rb
+++ b/lib/erubi.rb
@@ -1,30 +1,23 @@
 # frozen_string_literal: true
+require 'erb'
 
 module Erubi
   VERSION = '1.5.0'
-  ESCAPE_TABLE = {'&' => '&amp;'.freeze, '<' => '&lt;'.freeze, '>' => '&gt;'.freeze, '"' => '&quot;'.freeze, "'" => '&#039;'.freeze}.freeze
   RANGE_ALL = 0..-1
 
   if RUBY_VERSION >= '1.9'
     RANGE_FIRST = 0
     RANGE_LAST = -1
     TEXT_END = RUBY_VERSION >= '2.1' ? "'.freeze;" : "';"
-
-    # Escape the following characters with their HTML/XML
-    # equivalents.
-    def self.h(value)
-      value.to_s.gsub(/[&<>"']/, ESCAPE_TABLE)
-    end
   else
     # :nocov:
     RANGE_FIRST = 0..0
     RANGE_LAST = -1..-1
     TEXT_END = "';"
+  end
 
-    def self.h(value)
-      value.to_s.gsub(/[&<>"']/){|s| ESCAPE_TABLE[s]}
-    end
-    # :nocov:
+  def self.h(value)
+    ERB::Util.h(value)
   end
 
   class Engine

--- a/test/test.rb
+++ b/test/test.rb
@@ -101,7 +101,7 @@ END2
  <tbody>
   <tr>
    <td>1</td>
-   <td>&amp;&#039;&lt;&gt;&quot;2</td>
+   <td>&amp;&#39;&lt;&gt;&quot;2</td>
   </tr>
  </tbody>
 </table>
@@ -150,7 +150,7 @@ END2
  <tbody>
   <tr>
    <td>1</td>
-   <td>&amp;&#039;&lt;&gt;&quot;2</td>
+   <td>&amp;&#39;&lt;&gt;&quot;2</td>
   </tr>
  </tbody>
 </table>
@@ -472,7 +472,7 @@ END2
  <tbody>
   <tr>
    <td>1</td>
-   <td>&amp;&#039;&lt;&gt;&quot;2</td>
+   <td>&amp;&#39;&lt;&gt;&quot;2</td>
   </tr>
  </tbody>
 </table>


### PR DESCRIPTION
## Changes
I changed `Erubi.h` to use `ERB::Util.h` instead of `gsub`.

## Background
CGI.escapeHTML used in ERB::Util.h is faster than gsub with Ruby 2.3.0+.
https://github.com/ruby/ruby/pull/1164

With Ruby 2.4.0, erubi 1.5.0 and the following benchmark,

```rb
require 'benchmark/ips'
require 'erb'
require 'erubi'

Benchmark.ips do |x|
  str = '<script>alert("hello");</script>'
  x.report('Erubi.h') { Erubi.h(str) }
  x.report('ERB::Util.h') { ERB::Util.h(str) }
  x.compare!
end
```

the result is:

```
Warming up --------------------------------------
             Erubi.h    14.049k i/100ms
         ERB::Util.h    66.282k i/100ms
Calculating -------------------------------------
             Erubi.h    159.857k (± 3.6%) i/s -    800.793k in   5.016024s
         ERB::Util.h    954.032k (± 4.5%) i/s -      4.772M in   5.012803s

Comparison:
         ERB::Util.h:   954031.8 i/s
             Erubi.h:   159856.9 i/s - 5.97x  slower
```

## Notice
The escaped result of `'` will be changed from `#039;` to `#39;`. But it is compatible with Rails https://github.com/rails/rails/pull/22722.