### PR TITLE
Rename `.travis.gemfile` to `Gemfile`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /erubi-*.gem
 /rdoc/
 /coverage/
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,3 @@ matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
-gemfile: .travis.gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake', '<10.0.0'
-gem 'minitest'


### PR DESCRIPTION
**Before**:

`cannot load such file -- minitest/spec` from `test/test.rb:26`.

And `bundle` command doesn't help.

**After**:

Everything works.

**Bonus**:

Remove `minitest` from `Gemfile`, because it duplicates the same gem from `gemspec`:

```
Your Gemfile lists the gem minitest (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of one of them later
```