### PR TITLE
Use a range to select a substring of the input data

### DIFF
--- a/lib/erubi.rb
+++ b/lib/erubi.rb
@@ -93,8 +93,7 @@ module Erubi
       is_bol = true
       input.scan(regexp) do |indicator, code, tailch, rspace|
         match = Regexp.last_match
-        len  = match.begin(0) - pos
-        text = input[pos, len]
+        text = input[pos ... match.begin(0)]
         pos  = match.end(0)
         ch   = indicator ? indicator[RANGE_FIRST] : nil
 


### PR DESCRIPTION
I've just finished reading the code for this Gem. It's really great, thank you for that 🙇 When reading the code, I had problems understanding the first lines of the block passed to `input.scan` that cut out the code between the code blocks. When I finally understood what was going on, I had an idea to improve the readability of the code:

Instead of passing a position and a length, I would pass a range. That means we are handing in a start and an end position instead of a start position and a length. I think this makes it easier to understand.

What do you think?