### PR TITLE
remove unnecessary ternary operation

### DIFF
--- a/lib/erubi.rb
+++ b/lib/erubi.rb
@@ -123,7 +123,7 @@ module Erubi
           end
         end
 
-        is_bol = rspace ? true : false
+        is_bol = rspace
         add_text(text) if text && !text.empty?
         case ch
         when '='


### PR DESCRIPTION
`is_bol = rspace ? true : false` can be shorten as `is_bol = rspace` since `is_bol` is used as boolean flag for program, so even if `is_bol` becomes `nil`, it is still considered as falsely value and is evaluated as `false`.
