### PR TITLE
Add return_buffer option to CaptureEndEngine

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -92,6 +92,9 @@ instance variable.  Example:
   # </form>
   # after
 
+Alternatively, passing the option +:return_buffer => true+ will return the
+buffer captured by the block instead of the last expression in the block.
+
 = Reporting Bugs
 
 The bug tracker is located at https://github.com/jeremyevans/erubi/issues

--- a/lib/erubi/capture_end.rb
+++ b/lib/erubi/capture_end.rb
@@ -10,10 +10,13 @@ module Erubi
     # additional options:
     # :escape_capture :: Whether to make <%|= escape by default, and <%|== not escape by default,
     #                    defaults to the same value as :escape.
+    # :return_buffer :: Whether to return the buffer itself or the last expression of the block,
+    #                   defaults to false.
     def initialize(input, properties={})
       properties = Hash[properties]
       escape = properties.fetch(:escape){properties.fetch(:escape_html, false)}
       @escape_capture = properties.fetch(:escape_capture, escape)
+      @return_buffer = properties.fetch(:return_buffer, false)
       @bufval = properties[:bufval] ||= 'String.new'
       @bufstack = '__erubi_stack'
       properties[:regexp] ||= /<%(\|?={1,2}|-|\#|%|\|)?(.*?)([-=])?%>([ \t]*\r?\n)?/m
@@ -34,7 +37,8 @@ module Erubi
       when '|'
         rspace = nil if tailch && !tailch.empty?
         add_text(lspace) if lspace
-        src << code << ")).to_s; ensure; #{@bufvar} = #{@bufstack}.pop; end;"
+        result = @return_buffer ? "; #{@bufvar}; " : ""
+        src << code << result << ")).to_s; ensure; #{@bufvar} = #{@bufstack}.pop; end;"
         add_text(rspace) if rspace
       else
         super

--- a/test/test.rb
+++ b/test/test.rb
@@ -663,4 +663,47 @@ END3
     proc{Erubi::Engine.new('<%] %>', :regexp =>/<%(={1,2}|\]|-|\#|%)?(.*?)([-=])?%>([ \t]*\r?\n)?/m)}.must_raise ArgumentError
     proc{Erubi::CaptureEndEngine.new('<%] %>', :regexp =>/<%(={1,2}|\]|-|\#|%)?(.*?)([-=])?%>([ \t]*\r?\n)?/m)}.must_raise ArgumentError
   end
+
+  it "should return the last argument of the block without the :return_buffer option" do
+    @options[:engine] = ::Erubi::CaptureEndEngine
+
+    list = ['burgers', 'salads']
+    check_output(<<END1, <<END2, <<END3){}
+<%|= list.each do |item| %>
+Let's eat <%= item %>!
+<%| end %>
+END1
+_buf = String.new;begin; (__erubi_stack ||= []) << _buf; _buf = String.new; __erubi_stack.last << (( list.each do |item|  _buf << '
+'; _buf << 'Let\\'s eat '; _buf << ( item ).to_s; _buf << '!
+'; end )).to_s; ensure; _buf = __erubi_stack.pop; end; _buf << '
+';
+_buf.to_s
+END2
+["burgers", "salads"]
+END3
+  end
+
+  it "should return the buffer contents with the :return_buffer option" do
+    @options[:engine] = ::Erubi::CaptureEndEngine
+    @options[:return_buffer] = true
+
+    list = ['burgers', 'salads']
+    check_output(<<END1, <<END2, <<END3) {}
+<%|= list.each do |item| %>
+Let's eat <%= item %>!
+<%| end %>
+END1
+_buf = String.new;begin; (__erubi_stack ||= []) << _buf; _buf = String.new; __erubi_stack.last << (( list.each do |item|  _buf << '
+'; _buf << 'Let\\'s eat '; _buf << ( item ).to_s; _buf << '!
+'; end ; _buf; )).to_s; ensure; _buf = __erubi_stack.pop; end; _buf << '
+';
+_buf.to_s
+END2
+
+Let's eat burgers!
+
+Let's eat salads!
+
+END3
+  end
 end

--- a/test/test.rb
+++ b/test/test.rb
@@ -679,7 +679,7 @@ _buf = String.new;begin; (__erubi_stack ||= []) << _buf; _buf = String.new; __er
 ';
 _buf.to_s
 END2
-["burgers", "salads"]
+#{ list.to_s }
 END3
   end
 


### PR DESCRIPTION
With this option enabled, the buffer will be returned instead of the
last expression in the block passed to `<%|=`.

Spawned from the conversation in issue #15 