### PR TITLE
Fix and provide tests for :return_buffer option

### DIFF
--- a/lib/erubi/capture_end.rb
+++ b/lib/erubi/capture_end.rb
@@ -37,8 +37,8 @@ module Erubi
       when '|'
         rspace = nil if tailch && !tailch.empty?
         add_text(lspace) if lspace
-        result = @return_buffer ? "; #{@bufvar}; " : ""
-        src << code << result << ")).to_s; ensure; #{@bufvar} = #{@bufstack}.pop; end;"
+        result = @return_buffer ? " #{@bufvar}; " : ""
+        src << result << code << ")).to_s; ensure; #{@bufvar} = #{@bufstack}.pop; end;"
         add_text(rspace) if rspace
       else
         super

--- a/test/test.rb
+++ b/test/test.rb
@@ -713,4 +713,59 @@ LET'S EAT SALADS!
 B
 END3
   end
+
+  it "should respect the :return_buffer option for making templates return the (potentially modified) buffer as the result of the block" do
+    @options[:engine] = ::Erubi::CaptureEndEngine
+    @options[:return_buffer] = true
+
+    def self.bar(foo = nil)
+      if foo.nil?
+        yield
+      else
+        foo
+      end
+    end
+
+    check_output(<<END1, <<END2, <<END3) {}
+<%|= bar do %>
+Let's eat the tacos!
+<%| end %>
+
+Delicious!
+END1
+_buf = String.new;begin; (__erubi_stack ||= []) << _buf; _buf = String.new; __erubi_stack.last << (( bar do  _buf << '
+'; _buf << 'Let\\'s eat the tacos!
+'; _buf;  end )).to_s; ensure; _buf = __erubi_stack.pop; end; _buf << '
+'; _buf << '
+Delicious!
+';
+_buf.to_s
+END2
+
+Let's eat the tacos!
+
+
+Delicious!
+END3
+
+    check_output(<<END1, <<END2, <<END3) {}
+<%|= bar("Don't eat the burgers!") do %>
+Let's eat burgers!
+<%| end %>
+
+Delicious!
+END1
+_buf = String.new;begin; (__erubi_stack ||= []) << _buf; _buf = String.new; __erubi_stack.last << (( bar(\"Don't eat the burgers!\") do  _buf << '
+'; _buf << 'Let\\'s eat burgers!
+'; _buf;  end )).to_s; ensure; _buf = __erubi_stack.pop; end; _buf << '
+'; _buf << '
+Delicious!
+';
+_buf.to_s
+END2
+Don't eat the burgers!
+
+Delicious!
+END3
+  end
 end


### PR DESCRIPTION
Per our conversation on #16 I've added tests for the scenario where `<%|=` is needed with the `:return_buffer` option. While working through those tests, I realized I'd flipped the placement of `code` and `result` in `CaptureEndEngine`. 

One problem here is that the tests added with 9761dea506d935bf3517f11e155d801f49e43aa8 don't pass now, but I wasn't 100% confident that those should be removed. I was hoping you might provide some guidance on what those tests are covering that these new tests that I've added aren't or how they might be updated to pass.

Thanks again for you patience while I work through this stuff and for giving feedback!