### PR TITLE
Fix documentation of options bufval, bufvar in Erubi::Engine's initia…

### DIFF
--- a/lib/erubi.rb
+++ b/lib/erubi.rb
@@ -50,8 +50,8 @@ module Erubi
     attr_reader :bufvar
 
     # Initialize a new Erubi::Engine.  Options:
-    # :bufval :: The value to use for the buffer variable, as a string.
-    # :bufvar :: The variable name to use for the buffer variable, as a string (default '::String.new')
+    # :bufval :: The value to use for the buffer variable, as a string (default '::String.new').
+    # :bufvar :: The variable name to use for the buffer variable, as a string.
     # :ensure :: Wrap the template in a begin/ensure block restoring the previous value of bufvar.
     # :escapefunc :: The function to use for escaping, as a string (default: '::Erubi.h').
     # :escape :: Whether to make <%= escape by default, and <%== not escape by default.


### PR DESCRIPTION
…lizer

Hello, the documentation concerning the default value of options `:bufval` and `:bufvar` is mixed up. `'::String.new'` is the default for `:bufval` and NOT `:bufvar`: https://github.com/jeremyevans/erubi/blob/master/lib/erubi.rb#L72