### PR TITLE
Reduce memory usage when escaping text

### DIFF
--- a/lib/erubi.rb
+++ b/lib/erubi.rb
@@ -168,7 +168,17 @@ module Erubi
 
     # Add raw text to the template
     def add_text(text)
-      @src << " #{@bufvar} << '" << text.gsub(/['\\]/, '\\\\\&') << TEXT_END unless text.empty?
+      @src << " #{@bufvar} << '" << escape_text(text) << TEXT_END unless text.empty?
+    end
+
+    def escape_text(text)
+      if text.frozen?
+        text.gsub(/['\\]/, '\\\\\&')
+      else
+        text['\\'] = '\\\\' if text.include?('\\')
+        text["'"] = "\\'" if text.include?("'")
+        text
+      end
     end
 
     # Add ruby code to the template


### PR DESCRIPTION
I was playing with `erubi` and made a little experiment to reduce memory usage.

<details>
  <summary>Template</summary>
  
```ruby
<div itemscope itemtype='http://schema.org/ItemList'>
  <table class='category-list'>
    <thead>
      <tr>
        <th class='category'><%= t 'js.categories.category' %></th>
        <th class='topics'><%= t 'js.topic.list' %></th>
      </tr>
    </thead>
    <tbody>
      <meta itemprop='itemListOrder' content='http://schema.org/ItemListOrderDescending'>
      <% @category_list.categories.each_with_index do |c, index| %>
        <tr>
          <td class='category' style='border-color: #<%= c.color %>;'>
            <div itemprop='itemListElement' itemscope itemtype='http://schema.org/ListItem'>
              <meta itemprop='position' content='<%= index %>'>
              <meta itemprop='url' content='<%= c.url %>'>
              <h3>
                <a href='<%= c.url %>'>
                  <span itemprop='name'><%= c.name %></span>
                </a>
              </h3>
              <div itemprop='description'><%= c.description&.html_safe %></div>
            </div>
          </td>
          <td class='topics'>
            <div title='<%= c.topic_count %> <%= t 'js.topic.list' %>'><%= c.topic_count %></div>
          </td>
        </tr>
      <% end %>
    </tbody>
  </table>
</div>

<% content_for :title do %><%= @title %><% end %>

<% content_for :head do %>
  <%= raw crawlable_meta_data(title: SiteSetting.title, description: SiteSetting.site_description) %>
<% end %>
```
</details>

<details>
  <summary>Profile code</summary>

```ruby  
require 'erubi'

template = File.read('template.erb')

require 'memory_profiler'
MemoryProfiler.start

10_000.times do
  Erubi::Engine.new(template).src
end

report = MemoryProfiler.stop
report.pretty_print(to_file: 'tmp/memory_profiler.txt', scale_bytes: true)
```
</details>

### Before
```
Total allocated: 252.16 MB (2600001 objects)
Total retained:  2.47 kB (1 objects)
```

### After
```
Total allocated: 150.51 MB (1680001 objects)
Total retained:  2.47 kB (1 objects)
```

So, 40% memory memory savings.

That is some shitty code (😄 ), so please, feel free to close if it's not worth it, or suggest how it can be improved.