### PR TITLE
Allow the literal prefix/postfix to be configured

### DIFF
--- a/lib/erubi.rb
+++ b/lib/erubi.rb
@@ -147,7 +147,7 @@ module Erubi
             add_text(rspace)
           end
         when '%'
-          add_text("#{lspace}#{prefix||=literal_prefix}#{code}#{tailch}#{postfix||=literal_postfix}#{rspace}")
+          add_text("#{lspace}#{literal_prefix}#{code}#{tailch}#{literal_postfix}#{rspace}")
         when nil, '-'
           if trim && lspace && rspace
             add_code("#{lspace}#{code}#{rspace}")

--- a/lib/erubi.rb
+++ b/lib/erubi.rb
@@ -60,6 +60,8 @@ module Erubi
     # :escape_html :: Same as :escape, with lower priority.
     # :filename :: The filename for the template.
     # :freeze :: Whether to enable frozen string literals in the resulting source code.
+    # :literal_prefix :: What to output when the tag delimiters are escaped (<%%). Default <%
+    # :literal_postfix :: What to output when the tag delimiters are escaped. Default %>
     # :outvar :: Same as bufvar, with lower priority.
     # :postamble :: The postamble for the template, by default returns the resulting source code.
     # :preamble :: The preamble for the template, by default initializes up the buffer variable.
@@ -73,6 +75,8 @@ module Erubi
       @bufvar = bufvar = properties[:bufvar] || properties[:outvar] || "_buf"
       bufval = properties[:bufval] || '::String.new'
       regexp = properties[:regexp] || /<%(={1,2}|-|\#|%)?(.*?)([-=])?%>([ \t]*\r?\n)?/m
+      literal_prefix = properties[:literal_prefix] || '<%'
+      literal_postfix = properties[:literal_postfix] || '%>'
       preamble   = properties[:preamble] || "#{bufvar} = #{bufval};"
       postamble  = properties[:postamble] || "#{bufvar}.to_s\n"
 
@@ -143,7 +147,7 @@ module Erubi
             add_text(rspace)
           end
         when '%'
-          add_text("#{lspace}#{prefix||='<%'}#{code}#{tailch}#{postfix||='%>'}#{rspace}")
+          add_text("#{lspace}#{prefix||=literal_prefix}#{code}#{tailch}#{postfix||=literal_postfix}#{rspace}")
         when nil, '-'
           if trim && lspace && rspace
             add_code("#{lspace}#{code}#{rspace}")

--- a/test/test.rb
+++ b/test/test.rb
@@ -470,7 +470,7 @@ END2
 END3
   end
 
-  it "should handle <%% with a differnt literal prefix/postfix" do
+  it "should handle <%% with a different literal prefix/postfix" do
     @options[:literal_prefix] = "{%"
     @options[:literal_postfix] = "%}"
     @items = [2]

--- a/test/test.rb
+++ b/test/test.rb
@@ -470,6 +470,40 @@ END2
 END3
   end
 
+  it "should handle <%% with a differnt literal prefix/postfix" do
+    @options[:literal_prefix] = "{%"
+    @options[:literal_postfix] = "%}"
+    @items = [2]
+    i = 0
+    check_output(<<END1, <<END2, <<END3){}
+<table>
+  <%% for item in @items %>
+  <tr>
+  </tr>
+  <%% end %>
+  <%%= "literal" %>
+</table>
+END1
+_buf = ::String.new; _buf << '<table>
+'; _buf << '  {% for item in @items %}
+'; _buf << '  <tr>
+  </tr>
+'; _buf << '  {% end %}
+'; _buf << '  {%= "literal" %}
+'; _buf << '</table>
+';
+_buf.to_s
+END2
+<table>
+  {% for item in @items %}
+  <tr>
+  </tr>
+  {% end %}
+  {%= "literal" %}
+</table>
+END3
+  end
+
   it "should handle :trim => false option" do
     @options[:trim] = false
     @items = [2]


### PR DESCRIPTION
Fix for #26. Two additional properties were introduced: `literal_prefix` and `literal_postfix`, which default to `<%` and `%>` respectively. I also added a test for changing those two options. Let me know what you think. :)