### PR TITLE
Removing an unused constant

### DIFF
--- a/lib/erubi.rb
+++ b/lib/erubi.rb
@@ -2,7 +2,6 @@
 
 module Erubi
   VERSION = '1.10.0'
-  RANGE_ALL = 0..-1
 
   # :nocov:
   if RUBY_VERSION >= '1.9'


### PR DESCRIPTION
`RANGE_ALL` seems to be unused since 4dc81c210664bfa244c6015bb3aa034b29f5a66f.