### PR TITLE
Extract default Regexp to Constant

### DIFF
--- a/lib/erubi.rb
+++ b/lib/erubi.rb
@@ -44,6 +44,9 @@ module Erubi
   end
 
   class Engine
+    # The default regular expression used for scanning.
+    DEFAULT_REGEXP = /<%(={1,2}|-|\#|%)?(.*?)([-=])?%>([ \t]*\r?\n)?/m
+    
     # The frozen ruby source code generated from the template, which can be evaled.
     attr_reader :src
 
@@ -76,7 +79,7 @@ module Erubi
       @filename  = properties[:filename]
       @bufvar = bufvar = properties[:bufvar] || properties[:outvar] || "_buf"
       bufval = properties[:bufval] || '::String.new'
-      regexp = properties[:regexp] || /<%(={1,2}|-|\#|%)?(.*?)([-=])?%>([ \t]*\r?\n)?/m
+      regexp = properties[:regexp] || DEFAULT_REGEXP
       literal_prefix = properties[:literal_prefix] || '<%'
       literal_postfix = properties[:literal_postfix] || '%>'
       preamble   = properties[:preamble] || "#{bufvar} = #{bufval};"

--- a/lib/erubi.rb
+++ b/lib/erubi.rb
@@ -45,7 +45,7 @@ module Erubi
 
   class Engine
     # The default regular expression used for scanning.
-    DEFAULT_REGEXP = /<%(={1,2}|-|\#|%)?(.*?)([-=])?%>([ \t]*\r?\n)?/m
+    DEFAULT_REGEXP = /<%(={1,2}|-|\#|%)?(.*?)([-=])?%>([ \t]*\r?\n)?/m.freeze
     
     # The frozen ruby source code generated from the template, which can be evaled.
     attr_reader :src


### PR DESCRIPTION
I'm writing a erb linting tool for our Rails application. It's important that this tool is consistent with the default Erb parser.

Having the default Regexp as Constant would allow me to do scan with `Erubi::Engine::DEFAULT_REGEXP` thus ensure consistency.

I realise this helps me more than this project, but extracting to a constant seems like a nice little cleanup anyways, right?