### PR TITLE
Optimization: avoid the pop/putself combo when possible

### DIFF
--- a/lib/erubi/capture_end.rb
+++ b/lib/erubi/capture_end.rb
@@ -36,13 +36,16 @@ module Erubi
         rspace = nil if tailch && !tailch.empty?
         add_text(lspace) if lspace
         escape_capture = !((indicator == '|=') ^ @escape_capture)
+        pop_buffer
         src << "begin; (#{@bufstack} ||= []) << #{@bufvar}; #{@bufvar} = #{@bufval}; #{@bufstack}.last << #{@escapefunc if escape_capture}((" << code
+        @buffer_on_stack = false
         add_text(rspace) if rspace
       when '|'
         rspace = nil if tailch && !tailch.empty?
         add_text(lspace) if lspace
-        result = @yield_returns_buffer ? " #{@bufvar}; " : ""
+        result = @yield_returns_buffer ? "; #{@bufvar}; " : ""
         src << result << code << ")).to_s; ensure; #{@bufvar} = #{@bufstack}.pop; end;"
+        @buffer_on_stack = false
         add_text(rspace) if rspace
       else
         super


### PR DESCRIPTION
NB: all the tests that assert the generated code fail. They're easy to fix but I prefer to gauge interest first before I take the time to do it.

Erubi template generate code that keep putting the buffer back on the stack even though it's already there.

e.g.

```ruby
'<li>'.freeze; _buf << ( message ).to_s; _buf << '</li>
 <li>'.freeze; _buf << ( message ).to_s; _buf << '</li>
 <li>'.freeze; _buf << ( message ).to_s; _buf << '</li>'
```

could be:

```ruby
'<li>'.freeze << ( message ).to_s << '</li>
 <li>'.freeze << ( message ).to_s << '</li>
 <li>'.freeze << ( message ).to_s << '</li>'
```

Every `; _buf` sequence add two VM instruction:

```
0003 pop
0004 putself
```

Both can be avoided when the next instruction is to append to the buffer.

### Benchmark

```
Comparison:
        render patch:   855870.9 i/s
       render 1.10.0:   745255.2 i/s - 1.15x  (± 0.00) slower
```

```ruby
require 'erubi'
require 'benchmark/ips'
erb = Erubi::Engine.new(<<~ERB)
<html>
  <body>
    <ul>
      <li><%= message %></li>
      <li><%= message %></li>
      <li><%= message %></li>
      <% 2.times do |i| %>
        <li><%= i %></li>
      <% end %>
      <li><%= message %></li>
      <li><%= message %></li>
    </ul>
  </body>
</html>
ERB
src = "# frozen_string_literal: true\ndef render(message)\n#{erb.src}\nend"

puts "=" * 40
puts src
puts "=" * 40
eval(src)

Benchmark.ips do |x|
  x.report("render #{Erubi::VERSION}") do
    render("Hello")
  end
  x.save!("/tmp/erubi-bench-data")
  x.compare!
end
```