### PR TITLE
Fix typos in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,12 +1,12 @@
 = Erubi
 
-Erubi is a ERB template engine for ruby. It is a simplified fork of Erubis, using
+Erubi is an ERB template engine for Ruby. It is a simplified fork of Erubis, using
 the same basic algorithm, with the following differences:
 
 * Handles postfix conditionals when using escaping (e.g. <tt><%= foo if bar %></tt>)
 * Supports frozen_string_literal: true in templates via :freeze option
-* Works with ruby's <tt>--enable-frozen-string-literal</tt> option
-* Automatically freezes strings for template text when ruby optimizes it (on ruby 2.1+)
+* Works with Ruby's <tt>--enable-frozen-string-literal</tt> option
+* Automatically freezes strings for template text when Ruby optimizes it (on Ruby 2.1+)
 * Escapes <tt>'</tt> (apostrophe) when escaping for better XSS protection 
 * Has 15x-6x faster escaping by using erb/escape or cgi/escape
 * Has 81% smaller memory footprint (calculated using +ObjectSpace.memsize_of_all+)


### PR DESCRIPTION
# Changes
* a ERB => an ERB
* capitalize Ruby